### PR TITLE
Fix: Outputs of commands generating shell code are processed with `eval`, not `source`

### DIFF
--- a/bin/install-pip-deps
+++ b/bin/install-pip-deps
@@ -10,8 +10,7 @@ source "$(dirname "$(readlink -f "$0")")/activate"
 
 
 ## Determine collections and roles path
-source <(get-ansible-config COLLECTIONS_PATHS DEFAULT_ROLES_PATH)
-
+eval "$(get-ansible-config COLLECTIONS_PATHS DEFAULT_ROLES_PATH | sed 's/\\/\\\\/g; s/"/\"/g')"
 
 ## Scan the collections and roles path for 'requirements.txt' files and install PIP dependencies
 


### PR DESCRIPTION
This fixes running the affected scripts on old bash version present on macOS