### PR TITLE
Feature: Added Ansible Galaxy wrapper

### DIFF
--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+### Ansible Galaxy wrapper
+# Sets the ANSIBLE_COLLECTIONS_PATH and ANSIBLE_ROLES_PATH env variables
+# to skip the version-controlled 'collections/' and 'roles/' directories
+
+
+## Activate the project environment
+source "$(dirname "$(readlink -f "$0")")/activate"
+
+
+## Skip the version-controlled 'collections/' and 'roles/' directories
+
+# Determine collections and roles path from Ansible configuration
+eval "$(get-ansible-config COLLECTIONS_PATHS DEFAULT_ROLES_PATH)"
+
+## Override collections and roles path
+export ANSIBLE_COLLECTIONS_PATH="$(remove-from-path "$ANSIBLESITE/collections" "$COLLECTIONS_PATHS")"
+export ANSIBLE_ROLES_PATH="$(remove-from-path "$ANSIBLESITE/roles" "$DEFAULT_ROLES_PATH")"
+
+
+## Execute the real 'ansible-galaxy' command
+run-wrapped ansible-galaxy "$@"

--- a/bin/setup-galaxy
+++ b/bin/setup-galaxy
@@ -2,17 +2,11 @@
 
 ### Installs Ansible collections and roles using Ansible Galaxy
 # Performs the following actions:
-#   - for this run, overrides collections and roles install path 
-#     to 'external_roles' and 'external_collections', respectively
 #   - installs and/or upgrades Ansible collections from 'requirements.yml'
 #   - reinstalls Ansible roles from 'requirements.yml',
 #     as installing and/or upgrading only changed roles is not possible
 #   - if current environment's venv is active, calls 'install-pip-deps'
 #     to install PIP dependencies required by collections and roles
-#
-# Note: In order for the installed collections and roles to be found by Ansible,
-# the 'external_collections' directory must be present in the collections path
-# and the 'external_roles' directory must be present in the roles path.
 
 ## Activate the project environment
 source "$(dirname "$(readlink -f "$0")")/activate"
@@ -20,11 +14,6 @@ source "$(dirname "$(readlink -f "$0")")/activate"
 
 ## Define variables
 REQUIREMENTS="$ANSIBLESITE/requirements.yml"
-
-
-## Override collections and roles install path
-export ANSIBLE_COLLECTIONS_PATH="$ANSIBLESITE/external_collections"
-export ANSIBLE_ROLES_PATH="$ANSIBLESITE/external_roles"
 
 
 ## Install collections and roles


### PR DESCRIPTION
This wrapper removes the version-controlled directories from collections and roles paths, ensuring content is installed to the proper locations.

This PR resolves issue #23.