### PR TITLE
Compatibility of old bash: Added `source_generated` function

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -26,6 +26,41 @@ _get_script_path() {
     echo "$SOURCE"
 }
 
+# Helper function to add compatibility of sourcing dynamically-generated shell code
+# in older bash version
+if [[ "${BASH_VERSINFO+x}" && "$BASH_VERSINFO" -le 3 ]]; then
+    source_generated() {
+
+        #cat "$1"
+
+        # Process arguments
+        script_fd="$1"
+        shift
+
+        # Create a private temporary file
+        local script_temp="$(mktemp "${XDG_RUNTIME_DIR-"${TMPDIR-"/tmp"}"}"/bash-source-generated.XXXXXX)"
+
+        # Put the contents of the dynamically-generated file to the temporary file
+        cat "$script_fd" > "$script_temp"
+
+        # Source the temporary file and save exit status
+        local rc=0
+        source "$script_temp" "$@" || rc=$?
+
+        # Remove the temporary file
+        rm "$script_temp"
+
+        # Return with the exit code of the sourced script
+        return $rc
+
+    }
+else
+    source_generated() {
+        source "$@"
+    }
+fi
+
+
 # Function for removing custon directories from PATH
 _unset_path() {
     if [[ "$PATH:" == "$ANSIBLESITE_PATH:"* ]]; then

--- a/bin/ansible-galaxy
+++ b/bin/ansible-galaxy
@@ -12,7 +12,7 @@ source "$(dirname "$(readlink -f "$0")")/activate"
 ## Skip the version-controlled 'collections/' and 'roles/' directories
 
 # Determine collections and roles path from Ansible configuration
-source <(get-ansible-config COLLECTIONS_PATHS DEFAULT_ROLES_PATH)
+source_generated <(get-ansible-config COLLECTIONS_PATHS DEFAULT_ROLES_PATH)
 
 
 ## Override collections and roles path

--- a/bin/generate-vault-password
+++ b/bin/generate-vault-password
@@ -10,7 +10,7 @@ source "$(dirname "$(readlink -f "$0")")/activate"
 
 
 ## Get ansible vault password file location
-source <$(get-ansible-config DEFAULT_VAULT_PASSWORD_FILE)
+source_generated <$(get-ansible-config DEFAULT_VAULT_PASSWORD_FILE)
 
 
 ## Exit under certain conditions

--- a/bin/install-pip-deps
+++ b/bin/install-pip-deps
@@ -10,7 +10,7 @@ source "$(dirname "$(readlink -f "$0")")/activate"
 
 
 ## Determine collections and roles path
-source <(get-ansible-config COLLECTIONS_PATHS DEFAULT_ROLES_PATH)
+source_generated <(get-ansible-config COLLECTIONS_PATHS DEFAULT_ROLES_PATH)
 
 
 ## Scan the collections and roles path for 'requirements.txt' files and install PIP dependencies


### PR DESCRIPTION
The function is used when sourcing dynamic content using process substitution which does not work in old bash versions.

The function is implemented in two ways:
- on bash version 3 or lower, it copies the contents from the file descriptor to a temporary file, sourcing that instead.
- in all other cases, it calls `source` in turn