### PR TITLE
Fixed determining setup mode

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -127,8 +127,11 @@ ANSIBLESITE_PATH="$ANSIBLESITE_BIN:$ANSIBLESITE_EXTERNAL_BIN"
 ## Process arguments
 
 # determine the setup mode
-# shellcheck disable=SC2034
-ANSIBLESITE_SETUP_MODE="${1-}"
+echo "${ANSIBLESITE_SETUP_MODE=}" >/dev/null
+if [[ -n "${1-}" ]]; then
+    # shellcheck disable=SC2034
+    ANSIBLESITE_SETUP_MODE="$1"
+fi
 
 
 ## Activate the Python venv


### PR DESCRIPTION
Fixed the case when `$ANSIBLESITE_SETUP_MODE` is defined and `$1` is not.