### PR TITLE
Ansible vault password file is not generated automatically

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,6 +11,3 @@ roles_path=roles:.ansible/roles
 
 # Colon-separated paths in which Ansible will search for collections content.
 collections_path=collections:.ansible/collections
-
-# The vault password file to use.
-vault_password_file=.vault_pass

--- a/bin/activate
+++ b/bin/activate
@@ -153,6 +153,11 @@ _deactivate() {
     # Revert ANSIBLE_CONFIG
     _revert_saved_var ANSIBLE_CONFIG
 
+    # Revert ANSIBLE_VAULT_PASSWORD_FILE
+    if [[ "${_OLD_ANSIBLE_VAULT_PASSWORD_FILE+x}" ]]; then
+        _revert_saved_var ANSIBLE_VAULT_PASSWORD_FILE
+    fi
+
 
     ## Deactivate the Python venv, if it is activated
     if declare -f _venv_deactivate > /dev/null; then
@@ -181,6 +186,9 @@ ANSIBLESITE_EXTERNAL_BIN="$ANSIBLESITE/external_bin"
 
 # the directories from the workspace to add to PATH
 ANSIBLESITE_PATH="$ANSIBLESITE_BIN:$ANSIBLESITE_EXTERNAL_BIN"
+
+# the vault password file of the workspace
+ANSIBLESITE_VAULT_PASSWORD_FILE="$ANSIBLESITE/.vault_pass"
 
 
 ## Process arguments
@@ -239,6 +247,15 @@ fi
 _save_and_set_var ANSIBLE_CONFIG "$ANSIBLESITE_CONFIG"
 export ANSIBLE_CONFIG
 
+# Set the ANSIBLE_VAULT_PASSWORD_FILE to the value for this workspace ($ANSIBLESITE_VAULT_PASSWORD_FILE)
+# only if the file is present
+if [[ -f "$ANSIBLESITE_VAULT_PASSWORD_FILE" ]]; then
+    _save_and_set_var ANSIBLE_VAULT_PASSWORD_FILE "$ANSIBLESITE_VAULT_PASSWORD_FILE"
+    export ANSIBLE_VAULT_PASSWORD_FILE
+elif [[ "${_OLD_ANSIBLE_VAULT_PASSWORD_FILE+x}" ]]; then
+    _revert_saved_var ANSIBLE_VAULT_PASSWORD_FILE
+fi
+
 
 ## Declare the public deactivation function
 deactivate() {
@@ -260,6 +277,7 @@ deactivate() {
     unset ANSIBLESITE_BIN
     unset ANSIBLESITE_EXTERNAL_BIN
     unset ANSIBLESITE_PATH
+    unset ANSIBLESITE_VAULT_PASSWORD_FILE
     unset ANSIBLESITE_PROFILE
 
     # unset public functions

--- a/bin/generate-vault-password
+++ b/bin/generate-vault-password
@@ -20,14 +20,8 @@ source_generated <(get-ansible-config DEFAULT_VAULT_PASSWORD_FILE)
 
 ## Exit under certain conditions
 
-# Exit if no password file path is defined
-if [[ -z "${DEFAULT_VAULT_PASSWORD_FILE:-}" ]]; then
-    echo "$0: Ansible Vault password file path not defined, not generating a password." >&2
-    exit 0
-fi
-
 # Exit if file exists
-if [[ -e "$DEFAULT_VAULT_PASSWORD_FILE" ]]; then
+if [[ -e "$ANSIBLESITE_VAULT_PASSWORD_FILE" ]]; then
     echo "$0: Ansible Vault password file exists, not overwriting." >&2
     exit 0
 fi
@@ -39,8 +33,8 @@ fi
 echo "$0: Generating a password for Ansible Vault..." >&2
 
 # Create the file with secure permissions before generating password
-touch "$DEFAULT_VAULT_PASSWORD_FILE"
-chmod 600 "$DEFAULT_VAULT_PASSWORD_FILE"
+touch "$ANSIBLESITE_VAULT_PASSWORD_FILE"
+chmod 600 "$ANSIBLESITE_VAULT_PASSWORD_FILE"
 
 # Generate the password
-openssl rand -base64 32 > "$DEFAULT_VAULT_PASSWORD_FILE"
+openssl rand -base64 32 > "$ANSIBLESITE_VAULT_PASSWORD_FILE"

--- a/bin/setup
+++ b/bin/setup
@@ -5,7 +5,6 @@
 #   - runs 'setup-venv' to set up Python venv with dependencies
 #   - runs 'setup-galaxy' to download Ansible collections and roles using Ansible Galaxy
 #     and to install PIP dependencies required by them
-#   - runs 'generate-vault-password' to generate a password for Ansible Vault
 # This script passes the first command-line argument to 'setup-venv'
 # to specify the setup mode.
 
@@ -26,6 +25,3 @@ BIN="$(dirname "$(readlink -f "$0")")"
 # download Ansible collections and roles using Ansible Galaxy
 # and install PIP dependencies required by them
 "$BIN/setup-galaxy"
-
-# generate a password for Ansible Vault
-"$BIN/generate-vault-password"


### PR DESCRIPTION
Its usage is configured using environment variables during activation only if the file is present, preventing errors if the file does not exist.