### PR TITLE
Fixed scripts

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -96,7 +96,7 @@ case "$_ANSIBLESITE_SHELL" in
     zsh)
         _get_indirect() {
             # shellcheck disable=SC2296
-            print "${(P)${1}}"
+            print "${(P)${1}:-}"
         }
         _set_indirect() {
             typeset -g "$1=$2"
@@ -321,6 +321,7 @@ deactivate() {
     unset -f _save_and_set_var
     unset -f _revert_saved_var
     unset -f _unset_path
+    unset -f _load_vars
     unset -f _deactivate
 
     # unset this deactivation function

--- a/bin/setup-galaxy
+++ b/bin/setup-galaxy
@@ -34,7 +34,7 @@ ansible-galaxy role install -r "$REQUIREMENTS" --force
 ## Install PIP dependencies of collections and roles
 
 # check if the venv of the workspace is active
-if [[ "$VIRTUAL_ENV" = "$(realpath "$ANSIBLESITE_VENV")" ]]; then
+if [[ "${VIRTUAL_ENV+x}" && "$VIRTUAL_ENV" = "$(realpath "$ANSIBLESITE_VENV" 2> /dev/null || true)" ]]; then
 
     # call 'install-pip-deps' to install PIP dependencies
     # of collections and roles


### PR DESCRIPTION
Changes:
  - Fixed the `setup-galaxy` calling `install-pip-deps` when venv is not active and/or does not exist
  - Fixed undefined variables in the zsh variant of `_get_indirect`
  - Added missing `unset -f _load_vars` in deactivation function (see #90)